### PR TITLE
Remove readFile method, unused, can be replaced with Files.readAllLines

### DIFF
--- a/src/main/java/org/wildfly/util/yaml/anchor/template/Expander.java
+++ b/src/main/java/org/wildfly/util/yaml/anchor/template/Expander.java
@@ -95,20 +95,6 @@ public class Expander {
         }
     }
 
-    static String readFile(File file) throws Exception {
-        StringBuilder sb = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
-            String line = reader.readLine();
-            while (line != null) {
-                sb.append(line);
-                sb.append("\n");
-                line = reader.readLine();
-            }
-        }
-        return sb.toString();
-    }
-
-
     // Taken from https://stackoverflow.com/questions/18202548/java-snakeyaml-prevent-dumping-reference-names
     private class NonAnchorRepresenter extends Representer {
 


### PR DESCRIPTION
Removed readFile method, unused

Anyway, `Files.readAllLines` would be more JDK 1.8+ aligned approach